### PR TITLE
fixing versioning

### DIFF
--- a/Respify/Respify.csproj
+++ b/Respify/Respify.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Respify</PackageId>
-        <Version>1.0.1</Version>
+        <Version>1.1.0</Version>
         <PackageIcon>respify-icon.jpeg</PackageIcon>
         <Authors>Carlos Brunetti</Authors>
         <Description>A library to standardize API responses.</Description>


### PR DESCRIPTION
This pull request includes a version update for the `Respify` library in the `Respify.csproj` file. The version has been incremented from `1.0.1` to `1.1.0`.

* [`Respify/Respify.csproj`](diffhunk://#diff-31f19193a8e989e5b8b5f08e5282a5171c7d451dfe9430ec7ce632d536619314L9-R9): Updated the version from `1.0.1` to `1.1.0`.