### PR TITLE
added release branch name to be accepted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
       - develop
       - 'feature/*'
+      - 'release/*'
       - 'hotfix/*'
   pull_request:
     branches:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds the `release/*` branch pattern to the list of branches that trigger the CI workflow.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9): Added `release/*` branch pattern to the list of branches that trigger the CI workflow.